### PR TITLE
Add user agent support to Client

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -21,6 +21,7 @@ func withClient(tb testing.TB, h func(w http.ResponseWriter, r *http.Request), c
 			HTTPClient: server.Client(),
 			RetryCount: 2,
 			Servers:    []string{strings.TrimLeft(server.URL, "http://")},
+			UserAgent:  "custom-user-agent",
 		})
 		if err != nil {
 			tb.Fatal(err)
@@ -49,6 +50,9 @@ func TestClient(t *testing.T) {
 				if got, want := r.URL.RawQuery, "%7Bfoo%2Cbar%7D"; got != want {
 					t.Errorf("GOT: %v; WANT: %v", got, want)
 				}
+				if got, want := r.Header.Get("User-Agent"), "custom-user-agent"; got != want {
+					t.Errorf("GOT: %v; WANT: %v", got, want)
+				}
 			}
 			withClient(t, h, func(client *Client) {
 				_, err := client.Query("{foo,bar}")
@@ -68,6 +72,9 @@ func TestClient(t *testing.T) {
 
 			h := func(w http.ResponseWriter, r *http.Request) {
 				if got, want := r.URL.Path, "/range/list"; got != want {
+					t.Errorf("GOT: %v; WANT: %v", got, want)
+				}
+				if got, want := r.Header.Get("User-Agent"), "custom-user-agent"; got != want {
 					t.Errorf("GOT: %v; WANT: %v", got, want)
 				}
 				buf, err := bytesFromReadCloser(r.Body)

--- a/config.go
+++ b/config.go
@@ -46,6 +46,12 @@ type Config struct {
 	// Servers is slice of range server address strings.  Must contain at least
 	// one string.
 	Servers []string
+
+	// UserAgent is a string added to the HTTP headers and is intended to
+	// identify clients requesting online content.  When none is provided,
+	// the default Go user agent will be used.
+	// https://go.dev/src/net/http/request.go#L514
+	UserAgent string
 }
 
 // Doer performs the specfied http.Request and returns the http.Response.


### PR DESCRIPTION
Servers might have the need to distinguish clients from each other.  By default, Go uses the default user agent defined as "Go-http-client/1.1" which is not very descriptive.  This change allows clients to define their own user agent.